### PR TITLE
Partially remove requirement for completed save

### DIFF
--- a/PowerwashSimAP.csproj
+++ b/PowerwashSimAP.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>net48</TargetFramework>
         <AssemblyName>PowerwashSimAP</AssemblyName>
         <Product>PowerwashSimArchipelagoRandomizer</Product>
-        <Version>1.0.0</Version>
+        <Version>0.6.0</Version>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <LangVersion>13</LangVersion>
         <RestoreAdditionalProjectSources>

--- a/src/Patches/JobVisibilityPatcher.cs
+++ b/src/Patches/JobVisibilityPatcher.cs
@@ -1,0 +1,21 @@
+using BepInEx.Logging;
+using PWS;
+using HarmonyLib;
+using PlayFab.Internal;
+using UnityEngine;
+
+namespace PowerwashSimAP.Patches;
+
+public static class HasJobBeenPlayedPatch
+{
+    [HarmonyPatch(typeof(PWS.SaveManager), "HasJobBeenPlayed"), HarmonyPrefix]
+    public static bool Prefix(ref bool __result)
+    {
+        Plugin.Log.LogInfo($"HasJobBeenPlayedPatch::Prefix called, patching function");
+        // Pretend every job has been played
+        __result = true;
+
+        // Skip original method
+        return false;
+    }
+}

--- a/src/Patches/JobVisibilityPatcher.cs
+++ b/src/Patches/JobVisibilityPatcher.cs
@@ -19,3 +19,14 @@ public static class HasJobBeenPlayedPatch
         return false;
     }
 }
+
+public static class FreePlayUnlockPatch
+{
+    [HarmonyPatch(typeof(CampaignSaveData), "IsFreePlayUnlocked"), HarmonyPrefix]
+    static bool IsFreePlayUnlocked_Prefix(ref bool __result)
+    {
+        __result = true;  // All jobs unlocked, period
+        return false;     // Skip original method entirely
+    }
+}
+

--- a/src/Patches/JobVisibilityPatcher.cs
+++ b/src/Patches/JobVisibilityPatcher.cs
@@ -8,7 +8,7 @@ namespace PowerwashSimAP.Patches;
 
 public static class HasJobBeenPlayedPatch
 {
-    [HarmonyPatch(typeof(PWS.SaveManager), "HasJobBeenPlayed"), HarmonyPrefix]
+    [HarmonyPatch(typeof(SaveManager), "HasJobBeenPlayed"), HarmonyPrefix]
     public static bool Prefix(ref bool __result)
     {
         Plugin.Log.LogInfo($"HasJobBeenPlayedPatch::Prefix called, patching function");

--- a/src/Plugin.cs
+++ b/src/Plugin.cs
@@ -141,6 +141,7 @@ public class Plugin : BasePlugin
         Harmony.CreateAndPatchAll(typeof(MainMenuButtonPatch));
         Harmony.CreateAndPatchAll(typeof(WashTargetPatch));
         Harmony.CreateAndPatchAll(typeof(HasJobBeenPlayedPatch));
+        Harmony.CreateAndPatchAll(typeof(FreePlayUnlockPatch));
         // Harmony.CreateAndPatchAll(typeof(ShopPatch));
         // Harmony.CreateAndPatchAll(typeof(BuyPowerWasherPatch));
 

--- a/src/Plugin.cs
+++ b/src/Plugin.cs
@@ -140,6 +140,7 @@ public class Plugin : BasePlugin
         Harmony.CreateAndPatchAll(typeof(MainMenuPatch));
         Harmony.CreateAndPatchAll(typeof(MainMenuButtonPatch));
         Harmony.CreateAndPatchAll(typeof(WashTargetPatch));
+        Harmony.CreateAndPatchAll(typeof(HasJobBeenPlayedPatch));
         // Harmony.CreateAndPatchAll(typeof(ShopPatch));
         // Harmony.CreateAndPatchAll(typeof(BuyPowerWasherPatch));
 

--- a/src/Plugin.cs
+++ b/src/Plugin.cs
@@ -140,7 +140,7 @@ public class Plugin : BasePlugin
         Harmony.CreateAndPatchAll(typeof(MainMenuPatch));
         Harmony.CreateAndPatchAll(typeof(MainMenuButtonPatch));
         Harmony.CreateAndPatchAll(typeof(WashTargetPatch));
-        Harmony.CreateAndPatchAll(typeof(HasJobBeenPlayedPatch));
+        // Harmony.CreateAndPatchAll(typeof(HasJobBeenPlayedPatch));
         Harmony.CreateAndPatchAll(typeof(FreePlayUnlockPatch));
         // Harmony.CreateAndPatchAll(typeof(ShopPatch));
         // Harmony.CreateAndPatchAll(typeof(BuyPowerWasherPatch));


### PR DESCRIPTION
This PR partially removes the need for a complete save file, and makes it so you can play levels in free play that you haven't finished in career mode for the AP mod. I haven't delved into anything regarding the tools and whatnot, so I'm not sure if that will still need a somewhat progressed save in order to at least have some of them to be able to do the AP comfortably. 

This is still progress though :D 

The discoveries made in order to patch this would not have been possible without being able to reverse engineer some of the game code in Ghidra. 